### PR TITLE
Hotfix for bad integration test

### DIFF
--- a/lib/common/events_manager.dart
+++ b/lib/common/events_manager.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 abstract class EventsLoadListener {
   dynamic onLoadStart();
+
   dynamic onLoadFinished();
 }
 
@@ -114,8 +115,8 @@ class Event {
     int checkInCapacity = json['checkinCapac'] ?? 0;
     int updatedAt = json['updatedAt'] ?? 0;
     String code = json['code'] ?? '';
-    String longitude = json['longitude'] ?? '';
-    String latitude = json['latitude'] ?? '';
+    String longitude = '${json['longitude'] ?? ''}';
+    String latitude = '${json['latitude'] ?? ''}';
     String startDate = json['startDate'] ?? '';
     String endDate = json['endDate'] ?? '';
     String name = json['ename'] ?? '';


### PR DESCRIPTION
We originally used Strings for longitude and latitude. An integration test switched it to a number. This just makes a string regardless of what type it is.